### PR TITLE
Replace master with production in docs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -32,7 +32,7 @@ The list of people in this were those who dedicated their time to create the ori
 
 ## Contributor(s)
 
-This is list of those who have contributed to this code base through pull requests against the master branch and helped grow the website to what it is today. Each person has contributed in their own way and we thank them for their time! :hearts:
+This is list of those who have contributed to this code base through pull requests against the staging branch and helped grow the website to what it is today. Each person has contributed in their own way and we thank them for their time! :hearts:
 
 [Brenda Jin](https://github.com/brendajin)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # [Girl Develop It](http://girl-develop-it.herokuapp.com)
-[![Build Status](https://travis-ci.org/imuchnik/gdi-new-site.svg?branch=master)](https://travis-ci.org/imuchnik/gdi-new-site)
+[![Build Status](https://travis-ci.org/imuchnik/gdi-new-site.svg?branch=production)](https://travis-ci.org/imuchnik/gdi-new-site)
 
 This is the repo for the newly updated Girl Develop It website. In this README you'll find helpful resources to get you up and running to start contributing to the code base!
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 # Welcome to the [Girl Develop It Website](http://girl-develop-it.herokuapp.com) Documentation!
-[![Build Status](https://travis-ci.org/imuchnik/gdi-new-site.svg?branch=master)](https://travis-ci.org/imuchnik/gdi-new-site)
+[![Build Status](https://travis-ci.org/imuchnik/gdi-new-site.svg?branch=production)](https://travis-ci.org/imuchnik/gdi-new-site)
 
 This is the repo for the newly updated Girl Develop It website. In this README you'll find helpful resources to get you up and running to start contributing to the code base!
 

--- a/docs/sources/contribution.md
+++ b/docs/sources/contribution.md
@@ -16,10 +16,10 @@ If you are unfamiliar with forking, branching or working with git/Github, here a
 2. Switch to that new branch (e.g. `git checkout update-homepage`)
 3. Make your changes on your branch.
 4. Test it out locally by running `rails s` and visiting [http://0.0.0.0:3000](http://0.0.0.0:3000) in your favorite browser.
-5. Run `git fetch upstream` and then `git rebase upstream/master` in your branch.
+5. Run `git fetch upstream` and then `git rebase upstream/production` in your branch.
 6. Test again, see step 4.
 7. Push your branch to your repo (e.g. `git push origin update-homepage`)
-8. Make a pull request against the main repos master branch!
+8. Make a pull request against the main repos staging branch!
 
 We generally check all pull requests every 24-48 hours, but feel free to ping us on [Twitter](http://twitter.com/girldevelopit) if there is an urgent need.
 

--- a/docs/sources/deploying.md
+++ b/docs/sources/deploying.md
@@ -1,9 +1,9 @@
 ## Deploying to Heroku
 
-If you are an owner and/or have been approved by one of the [Project Leads](https://github.com/girldevelopit/gdi-new-site/blob/master/CONTRIBUTORS.md#project-leads), than this section is relevant to you!
+If you are an owner and/or have been approved by one of the [Project Leads](https://github.com/girldevelopit/gdi-new-site/blob/production/CONTRIBUTORS.md#project-leads), than this section is relevant to you!
 
 1. Be sure that have the [Heroku tool belt](https://toolbelt.heroku.com/) installed.
 2. Add a remote to the GDI Heroku instance with `heroku git:remote -a girl-develop-it`.
-3. Now deploy to Heroku with `git push heroku master`.
+3. Now deploy to Heroku with `git push heroku production`.
 
 **NOTE:** This process will be updated as we start incorporating continuous integration processes, as well as after the site goes officially live.

--- a/docs/sources/index.md
+++ b/docs/sources/index.md
@@ -1,5 +1,5 @@
 # Welcome to the [Girl Develop It Website](http://girl-develop-it.herokuapp.com) Documentation!
-[![Build Status](https://travis-ci.org/imuchnik/gdi-new-site.svg?branch=master)](https://travis-ci.org/imuchnik/gdi-new-site)
+[![Build Status](https://travis-ci.org/imuchnik/gdi-new-site.svg?branch=production)](https://travis-ci.org/imuchnik/gdi-new-site)
 
 This is the repo for the newly updated Girl Develop It website. In this README you'll find helpful resources to get you up and running to start contributing to the code base!
 


### PR DESCRIPTION
Removing all instances of 'master' so contributors know to use the staging>production process
