### PR TITLE
Adding validation to geo and chapter fields to reduce geocode errors

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -2,6 +2,8 @@ class Chapter < ActiveRecord::Base
   extend FriendlyId
   friendly_id :chapter, use: [:slugged, :history]
 
+  validates :geo, :chapter, presence: true
+
   resourcify
   has_many :admin_users
   has_many :sponsors
@@ -16,5 +18,7 @@ class Chapter < ActiveRecord::Base
       obj.state = geocoded.state
     end
   end
+
   after_validation :reverse_geocode
+  
 end


### PR DESCRIPTION
Having trouble replicating the null state issue, but let's at least make the chapter name and location required fields to reduce the chances.
