### PR TITLE
Replace "him or her" in Code of Conduct

### DIFF
--- a/app/views/home/code-of-conduct.html.erb
+++ b/app/views/home/code-of-conduct.html.erb
@@ -18,7 +18,7 @@
         <h3>Use of Sexualized Imagery</h3>
         <p>Teachers, event organizers, volunteers, and hosts are also subject to the anti-harassment policy. In particular, teachers/hosts/organizers should not use sexualized images, activities, or other material. GDI organizers, teachers, teachers assistants, and event hosts (including volunteers) should not use sexualized clothing/uniforms/costumes, or otherwise create a sexualized environment.</p><br>
         <h3>Consequences Of Unacceptable Behavior</h3>
-        <p>If a participant engages in harassing behavior, the Girl Develop It organizers may take any action they deem appropriate, including warning the offender or expelling him or her from the class/event/meetup group [with no refund]. </p><br>
+        <p>If a participant engages in harassing behavior, the Girl Develop It organizers may take any action they deem appropriate, including warning the offender or expelling them from the class/event/meetup group [with no refund]. </p><br>
         <h3>What To Do If You Witness Or Are Subject To Unacceptable Behavior</h3>
         <p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact your local Chapter Leader(s) immediately. Contact information for your local Chapter Leader can be found on <%= link_to "our Chapters page", chapters_path %>.</p>
         <p>Girl Develop It Chapter Leaders/Teachers/Event Organizers will be happy to help members contact local law enforcement, provide escorts when possible and with reasonable notice, or otherwise assist those experiencing harassment to feel safe for the duration of the event/class. We value your attendance.</p>


### PR DESCRIPTION
There doesn't seem to be any reason to use "him or her" as language in this code of conduct.  "Them" works just as well in this sentence and doesn't suggest that there are only "hims" and "hers" offending people.

I understand this a totally trivial change, but I would totally appreciate it if the Code of Conduct wasn't upholding a "false" binary gender system.  Thanks!
