### PR TITLE
Adding is_active functionality for chapter admin

### DIFF
--- a/app/admin/admin_user.rb
+++ b/app/admin/admin_user.rb
@@ -27,7 +27,7 @@ ActiveAdmin.register AdminUser do
       f.input :email, placeholder: "email@example.com"
       f.input :password
       f.input :password_confirmation
-      f.input :chapter, member_label: :chapter, :collection => Chapter.where("is_active = 1").order("chapter ASC")
+      f.input :chapter, member_label: :chapter, :collection => Chapter.active.order("chapter ASC")
       f.input :roles
     end
     f.actions

--- a/app/admin/admin_user.rb
+++ b/app/admin/admin_user.rb
@@ -27,7 +27,7 @@ ActiveAdmin.register AdminUser do
       f.input :email, placeholder: "email@example.com"
       f.input :password
       f.input :password_confirmation
-      f.input :chapter, member_label: :chapter, :collection => Chapter.order("chapter ASC").all
+      f.input :chapter, member_label: :chapter, :collection => Chapter.where("is_active = 1").order("chapter ASC")
       f.input :roles
     end
     f.actions

--- a/app/admin/bio.rb
+++ b/app/admin/bio.rb
@@ -47,7 +47,7 @@ ActiveAdmin.register Bio do
         f.input :chapter_id, :input_html => { :value => current_admin_user.chapter_id }, as: :hidden
       else
         #otherwise, admin can pick the chapter for the new bio using dropdown list :chapter
-        f.input :chapter, member_label: :chapter, :collection => Chapter.order("chapter ASC").all
+        f.input :chapter, member_label: :chapter, :collection => Chapter.where("is_active = 1").order("chapter ASC")
       end
       #f.input :admin_user
       f.input :title, as: :select, collection: ['LEADERS', 'INSTRUCTORS', 'VOLUNTEERS']

--- a/app/admin/bio.rb
+++ b/app/admin/bio.rb
@@ -30,7 +30,7 @@ ActiveAdmin.register Bio do
   end
 
   filter :roles
-  filter :chapter, member_label: :chapter, collection: proc { Chapter.order(:chapter) }
+  filter :chapter, member_label: :chapter, collection: proc { Chapter.active.order(:chapter) }
   filter :name
   filter :title
   filter :info
@@ -42,12 +42,12 @@ ActiveAdmin.register Bio do
   form(:html => { :multipart => true }) do |f|
     f.inputs "Edit Bio" do
       #if user only has one role and it is leader...
-      if current_admin_user.roles.count == 1 and current_admin_user.roles.first.name == "leader"
+      if current_admin_user.has_one_role? && current_admin_user.leader?
         #...then set the chapter_id to the leader's chapter_id
         f.input :chapter_id, :input_html => { :value => current_admin_user.chapter_id }, as: :hidden
       else
         #otherwise, admin can pick the chapter for the new bio using dropdown list :chapter
-        f.input :chapter, member_label: :chapter, :collection => Chapter.where("is_active = 1").order("chapter ASC")
+        f.input :chapter, member_label: :chapter, :collection => Chapter.active.order("chapter ASC")
       end
       #f.input :admin_user
       f.input :title, as: :select, collection: ['LEADERS', 'INSTRUCTORS', 'VOLUNTEERS']

--- a/app/admin/chapter.rb
+++ b/app/admin/chapter.rb
@@ -1,10 +1,9 @@
 ActiveAdmin.register Chapter do
 
-
   # See permitted parameters documentation:
   # https://github.com/gregbell/active_admin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
   #
-  permit_params :chapter, :blurb, :fb, :meetup, :twitter, :linkedin, :github, :geo, :email, :meetup_id
+  permit_params :chapter, :blurb, :fb, :meetup, :twitter, :linkedin, :github, :geo, :email, :meetup_id, :is_active
   #
   index do
     selectable_column
@@ -27,6 +26,11 @@ ActiveAdmin.register Chapter do
 
   form do |f|
     f.inputs "Edit Chapter" do
+      #if user only has one role and it is leader...
+      if current_admin_user.roles.count == 1 and current_admin_user.roles.first.name == "admin"
+        #admin users can activate/deactivate chapters as needed
+        f.input :is_active, as: :radio, :collection => { "Yes" => 1, "No" => 0}, label: "Active?", include_blank: false
+      end
       f.input :chapter, placeholder: "Los Angeles"
       f.input :geo, label: "Address", placeholder: "Los Angeles, CA, USA"
       f.input :fb, label: "Facebook", placeholder: "GDILosAngeles"
@@ -47,6 +51,5 @@ ActiveAdmin.register Chapter do
   #  permitted << :other if resource.something?
   #  permitted
   # end
-
 
 end

--- a/app/admin/chapter.rb
+++ b/app/admin/chapter.rb
@@ -27,9 +27,9 @@ ActiveAdmin.register Chapter do
   form do |f|
     f.inputs "Edit Chapter" do
       #if user only has one role and it is leader...
-      if current_admin_user.roles.count == 1 and current_admin_user.roles.first.name == "admin"
+      if current_admin_user.has_one_role? && current_admin_user.admin?
         #admin users can activate/deactivate chapters as needed
-        f.input :is_active, as: :radio, :collection => { "Yes" => 1, "No" => 0}, label: "Active?", include_blank: false
+        f.input :is_active, as: :radio, :collection => { "Yes" => true, "No" => false}, label: "Active?", include_blank: false
       end
       f.input :chapter, placeholder: "Los Angeles"
       f.input :geo, label: "Address", placeholder: "Los Angeles, CA, USA"

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -3,31 +3,21 @@ ActiveAdmin.register_page "Dashboard" do
   menu priority: 1, label: proc{ I18n.t("active_admin.dashboard") }
 
   content title: proc{ I18n.t("active_admin.dashboard") } do
-    div class: "blank_slate_container", id: "dashboard_default_message" do
-      span class: "blank_slate" do
-        span I18n.t("active_admin.dashboard_welcome.welcome")
-        small I18n.t("active_admin.dashboard_welcome.call_to_action")
+
+    columns do
+      column do
+        panel "Info" do
+            @user_chapter = Chapter.where(id: current_admin_user.chapter_id)
+            @user_chapter.each do |c|
+                if c.is_active == 1
+                    para "Welcome to Girl Develop It's Web Admin portal. Please contact the web admin team via Slack (#website) or by emailing website@girldevelopit.com if you have any questions."
+                else
+                    para "Your chapter has been deactivated."
+                end
+            end
+        end
       end
     end
 
-    # Here is an example of a simple dashboard with columns and panels.
-    #
-    # columns do
-    #   column do
-    #     panel "Recent Posts" do
-    #       ul do
-    #         Post.recent(5).map do |post|
-    #           li link_to(post.title, admin_post_path(post))
-    #         end
-    #       end
-    #     end
-    #   end
-
-    #   column do
-    #     panel "Info" do
-    #       para "Welcome to ActiveAdmin."
-    #     end
-    #   end
-    # end
   end # content
 end

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -9,7 +9,7 @@ ActiveAdmin.register_page "Dashboard" do
         panel "Info" do
             @user_chapter = Chapter.where(id: current_admin_user.chapter_id)
             @user_chapter.each do |c|
-                if c.is_active == 1
+                if c.is_active?
                     para "Welcome to Girl Develop It's Web Admin portal. Please contact the web admin team via Slack (#website) or by emailing website@girldevelopit.com if you have any questions."
                 else
                     para "Your chapter has been deactivated."

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -9,7 +9,7 @@ ActiveAdmin.register_page "Dashboard" do
         panel "Info" do
             @user_chapter = Chapter.where(id: current_admin_user.chapter_id)
             @user_chapter.each do |c|
-                if c.is_active?
+                if c.is_active
                     para "Welcome to Girl Develop It's Web Admin portal. Please contact the web admin team via Slack (#website) or by emailing website@girldevelopit.com if you have any questions."
                 else
                     para "Your chapter has been deactivated."

--- a/app/admin/sponsor.rb
+++ b/app/admin/sponsor.rb
@@ -35,7 +35,7 @@ ActiveAdmin.register Sponsor do
         f.input :chapter_id, :input_html => { :value => current_admin_user.chapter_id }, as: :hidden
       else
         #otherwise, admin can pick the chapter for the new sponsor using dropdown list :chapter
-        f.input :chapter, member_label: :chapter, :collection => Chapter.order("chapter ASC").all
+        f.input :chapter, member_label: :chapter, :collection => Chapter.where("is_active = 1").order("chapter ASC")
       end
       f.input :name, placeholder: "The Iron Yard"
       f.input :sort_order, as: :select, collection: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20], include_blank: false

--- a/app/admin/sponsor.rb
+++ b/app/admin/sponsor.rb
@@ -21,7 +21,7 @@ ActiveAdmin.register Sponsor do
   end
 
   filter :roles
-  filter :chapter, member_label: :chapter, collection: proc { Chapter.order(:chapter) }
+  filter :chapter, member_label: :chapter, collection: proc { Chapter.active.order(:chapter) }
   filter :name
   filter :url
   filter :created_at
@@ -30,12 +30,12 @@ ActiveAdmin.register Sponsor do
   form(:html => { :multipart => true }) do |f|
   f.inputs "Edit Sponsor" do
       #if user only has one role and it is leader...
-      if current_admin_user.roles.count == 1 and current_admin_user.roles.first.name == "leader"
+      if current_admin_user.has_one_role? && current_admin_user.leader?
         #...then set the chapter_id to the leader's chapter_id
         f.input :chapter_id, :input_html => { :value => current_admin_user.chapter_id }, as: :hidden
       else
         #otherwise, admin can pick the chapter for the new sponsor using dropdown list :chapter
-        f.input :chapter, member_label: :chapter, :collection => Chapter.where("is_active = 1").order("chapter ASC")
+        f.input :chapter, member_label: :chapter, :collection => Chapter.active.order("chapter ASC")
       end
       f.input :name, placeholder: "The Iron Yard"
       f.input :sort_order, as: :select, collection: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20], include_blank: false

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -1,7 +1,7 @@
 class ChaptersController < ApplicationController
   require 'rails_autolink'
   def index
-    @chapters = Chapter.order("chapter ASC").all
+    @chapters = Chapter.where("is_active = 1").order("chapter ASC")
     states = {}
     @chapters.each do |l|
       if states[l.state]
@@ -20,6 +20,10 @@ end
 
   def show
     @chapter = Chapter.friendly.find(params[:id])
+    #Make sure the chapter is active...
+    if @chapter.is_active != 1
+      redirect_to({ action: 'index' }, alert: @chapter.chapter + " is no longer an active chapter.")
+    end
     if request.path != chapter_path(@chapter)
       redirect_to @chapter, status: :moved_permanently
     end

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -1,7 +1,7 @@
 class ChaptersController < ApplicationController
   require 'rails_autolink'
   def index
-    @chapters = Chapter.where("is_active = 1").order("chapter ASC")
+    @chapters = Chapter.active.order("chapter ASC")
     states = {}
     @chapters.each do |l|
       if states[l.state]
@@ -20,8 +20,8 @@ end
 
   def show
     @chapter = Chapter.friendly.find(params[:id])
-    #Make sure the chapter is active...
-    if @chapter.is_active != 1
+    #Make sure the chapter is active otherwise redirect to index
+    if !@chapter.is_active
       redirect_to({ action: 'index' }, alert: @chapter.chapter + " is no longer an active chapter.")
     end
     if request.path != chapter_path(@chapter)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,14 +1,18 @@
 class HomeController < ApplicationController
 
   def index
-  @chapters = Chapter.where("is_active = 1")
-  @chapter = Chapter.where("is_active = 1")
+  @chapters = Chapter.active
+  @chapter = Chapter.active
   end
 
   def about
-  	@chapter_count = Chapter.where("is_active = 1").count
+  	@chapter_count = Chapter.active.count
   end
 
   def donate
+  end
+
+  def supporters
+  	@chapter_count = Chapter.active.count
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,12 +1,12 @@
 class HomeController < ApplicationController
 
   def index
-  @chapters = Chapter.all
-  @chapter = Chapter.all
+  @chapters = Chapter.where("is_active = 1")
+  @chapter = Chapter.where("is_active = 1")
   end
 
   def about
-  	@chapter_count = Chapter.count
+  	@chapter_count = Chapter.where("is_active = 1").count
   end
 
   def donate

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -34,7 +34,7 @@ class Ability
     #if not, only let them see Dashboard with information about deactivation
     @user_chapter = Chapter.where(id: user.chapter_id)
     @user_chapter.each do |c|
-      if c.is_active != 1
+      if !c.is_active
         cannot :read, :all
         can :read, ActiveAdmin::Page, name: 'Dashboard'
       end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -29,5 +29,15 @@ class Ability
     else
       can :view, :all
     end
+
+    #check if user's chapter is active
+    #if not, only let them see Dashboard with information about deactivation
+    @user_chapter = Chapter.where(id: user.chapter_id)
+    @user_chapter.each do |c|
+      if c.is_active != 1
+        cannot :read, :all
+        can :read, ActiveAdmin::Page, name: 'Dashboard'
+      end
+    end
   end
 end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -7,4 +7,16 @@ class AdminUser < ActiveRecord::Base
   has_one :bio
   belongs_to :chapter
   accepts_nested_attributes_for :roles
+
+  	def has_one_role?
+	  roles.count == 1
+	end
+
+	def admin?
+	  roles.first.name == "admin"
+	end
+
+	def leader?
+	  roles.first.name == "leader"
+	end
 end

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -35,4 +35,6 @@ class Chapter < ActiveRecord::Base
 
   after_validation :reverse_geocode
   
+  scope :active, -> { where(is_active: true) }
+  
 end

--- a/app/views/home/supporters.html.erb
+++ b/app/views/home/supporters.html.erb
@@ -8,7 +8,7 @@
         <h2>Supporters</h2>
         <hr>
       </div>
-      <p class="large">Supporters of Girl Develop It make a commitment to diversity in tech. By supporting our organization, you are helping us grow our impact. Girl Develop It is currently serving 35,000 members in 50 cities in the US. With the support of companies like yours, we are better equipped to expand and deepen our impact. Our organization is more than just classes. Girl Develop It’s in-person, culture-centered approach to create learning communities means that women progress from students to teachers to leaders and technical professionals over time.</p>
+      <p class="large">Supporters of Girl Develop It make a commitment to diversity in tech. By supporting our organization, you are helping us grow our impact. Girl Develop It is currently serving 55,000+ members in <%= @chapter_count %> cities in the US. With the support of companies like yours, we are better equipped to expand and deepen our impact. Our organization is more than just classes. Girl Develop It’s in-person, culture-centered approach to create learning communities means that women progress from students to teachers to leaders and technical professionals over time.</p>
 
       <div class="underlined-headline">
         <h2>Sponsors</h2>

--- a/db/migrate/20151221234035_add_is_active_to_chapters.rb
+++ b/db/migrate/20151221234035_add_is_active_to_chapters.rb
@@ -1,5 +1,5 @@
 class AddIsActiveToChapters < ActiveRecord::Migration
   def change
-    add_column :chapters, :is_active, :integer, :default => 1
+    add_column :chapters, :is_active, :boolean, default: true
   end
 end

--- a/db/migrate/20151221234035_add_is_active_to_chapters.rb
+++ b/db/migrate/20151221234035_add_is_active_to_chapters.rb
@@ -1,0 +1,5 @@
+class AddIsActiveToChapters < ActiveRecord::Migration
+  def change
+    add_column :chapters, :is_active, :integer, :default => 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -94,7 +94,7 @@ ActiveRecord::Schema.define(version: 20151221234035) do
     t.string   "state"
     t.string   "email"
     t.string   "slug"
-    t.integer  "is_active",  default: 1
+    t.boolean  "is_active",  default: true
   end
 
   add_index "chapters", ["slug"], name: "index_chapters_on_slug", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150310040256) do
+ActiveRecord::Schema.define(version: 20151221234035) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -94,6 +94,7 @@ ActiveRecord::Schema.define(version: 20150310040256) do
     t.string   "state"
     t.string   "email"
     t.string   "slug"
+    t.integer  "is_active",  default: 1
   end
 
   add_index "chapters", ["slug"], name: "index_chapters_on_slug", using: :btree

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,7 +14,8 @@ leader = Role.create! do |a|
 #give role privileges to default admin user created by Devise
 adminfirst = AdminUser.first
 adminfirst.roles << admin
-adminfirst.roles << leader
+#only need admin role for all-access
+#adminfirst.roles << leader
 
 chapter_seed = Rails.root.join('db', 'seeds', 'sample-locs.yml')
 


### PR DESCRIPTION
Implemented some functionality that allows us to control whether or not a chapter is active and the subsequent website/user experience in either state:
- Added is_active field to chapters table and updated migration files to include default 1 (active) value
- Changed all Chapter finds to include where("id = 1") to only return active chapters
  - Results indicated on about page, home page map, and chapters page
- Updated ActiveAdmin views to only show active chapters in filter dropdowns
- Updated messages and user privileges for when admin user's chapter is deactivated
- Only admin-level users (not leaders) can edit status of a chapter

Admin-only editing capability:
![screen shot 2015-12-21 at 9 15 33 pm](https://cloud.githubusercontent.com/assets/6612770/11946544/c6764984-a829-11e5-8161-2bc19397b6bc.png)

Activate chapter user Dashboard:
![screen shot 2015-12-21 at 9 15 54 pm](https://cloud.githubusercontent.com/assets/6612770/11946550/d1047088-a829-11e5-8f76-1cf67bd27a9b.png)

Deactivated chapter user Dashboard:
![screen shot 2015-12-21 at 9 16 28 pm](https://cloud.githubusercontent.com/assets/6612770/11946554/d627b3e0-a829-11e5-9c89-afcdd45500c1.png)

An alert is shown for any attempt to visit the page of a deactivated chapter. Currently, "[Chapter name] is no longer an active chapter."
