### PR TITLE
Minor adjustments to is_active code

### DIFF
--- a/app/admin/bio.rb
+++ b/app/admin/bio.rb
@@ -41,13 +41,12 @@ ActiveAdmin.register Bio do
 
   form(:html => { :multipart => true }) do |f|
     f.inputs "Edit Bio" do
-      #if user only has one role and it is leader...
-      if current_admin_user.has_one_role? && current_admin_user.leader?
-        #...then set the chapter_id to the leader's chapter_id
-        f.input :chapter_id, :input_html => { :value => current_admin_user.chapter_id }, as: :hidden
-      else
-        #otherwise, admin can pick the chapter for the new bio using dropdown list :chapter
+      #if user is admin, show dropdown
+      if current_admin_user.admin?
         f.input :chapter, member_label: :chapter, :collection => Chapter.active.order("chapter ASC")
+      else 
+        #...else user is leader so set the chapter_id to the leader's chapter_id
+        f.input :chapter_id, :input_html => { :value => current_admin_user.chapter_id }, as: :hidden
       end
       #f.input :admin_user
       f.input :title, as: :select, collection: ['LEADERS', 'INSTRUCTORS', 'VOLUNTEERS']

--- a/app/admin/bio.rb
+++ b/app/admin/bio.rb
@@ -41,8 +41,8 @@ ActiveAdmin.register Bio do
 
   form(:html => { :multipart => true }) do |f|
     f.inputs "Edit Bio" do
-      #if user is admin, show dropdown
       if current_admin_user.admin?
+        #if user is admin, show chapter list dropdown
         f.input :chapter, member_label: :chapter, :collection => Chapter.active.order("chapter ASC")
       else 
         #...else user is leader so set the chapter_id to the leader's chapter_id

--- a/app/admin/chapter.rb
+++ b/app/admin/chapter.rb
@@ -26,7 +26,6 @@ ActiveAdmin.register Chapter do
 
   form do |f|
     f.inputs "Edit Chapter" do
-      #if user only has one role and it is admin...
       if current_admin_user.admin?
         #admin users can activate/deactivate chapters as needed
         f.input :is_active, as: :radio, :collection => { "Yes" => true, "No" => false}, label: "Active?", include_blank: false

--- a/app/admin/chapter.rb
+++ b/app/admin/chapter.rb
@@ -26,8 +26,8 @@ ActiveAdmin.register Chapter do
 
   form do |f|
     f.inputs "Edit Chapter" do
-      #if user only has one role and it is leader...
-      if current_admin_user.has_one_role? && current_admin_user.admin?
+      #if user only has one role and it is admin...
+      if current_admin_user.admin?
         #admin users can activate/deactivate chapters as needed
         f.input :is_active, as: :radio, :collection => { "Yes" => true, "No" => false}, label: "Active?", include_blank: false
       end

--- a/app/admin/sponsor.rb
+++ b/app/admin/sponsor.rb
@@ -29,13 +29,12 @@ ActiveAdmin.register Sponsor do
 
   form(:html => { :multipart => true }) do |f|
   f.inputs "Edit Sponsor" do
-      #if user only has one role and it is leader...
-      if current_admin_user.has_one_role? && current_admin_user.leader?
-        #...then set the chapter_id to the leader's chapter_id
-        f.input :chapter_id, :input_html => { :value => current_admin_user.chapter_id }, as: :hidden
-      else
-        #otherwise, admin can pick the chapter for the new sponsor using dropdown list :chapter
+      if current_admin_user.admin?
+        #admin can pick the chapter for the new sponsor using dropdown list :chapter
         f.input :chapter, member_label: :chapter, :collection => Chapter.active.order("chapter ASC")
+      else
+        #...else set the chapter_id to the leader's chapter_id
+        f.input :chapter_id, :input_html => { :value => current_admin_user.chapter_id }, as: :hidden
       end
       f.input :name, placeholder: "The Iron Yard"
       f.input :sort_order, as: :select, collection: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20], include_blank: false

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -8,15 +8,8 @@ class AdminUser < ActiveRecord::Base
   belongs_to :chapter
   accepts_nested_attributes_for :roles
 
-  	def has_one_role?
-	  roles.count == 1
-	end
-
 	def admin?
-	  roles.first.name == "admin"
+    roles.any?{|role| role.name == "admin"}
 	end
-
-	def leader?
-	  roles.first.name == "leader"
-	end
+  
 end


### PR DESCRIPTION
I really didn't like the route we were heading with the has_one_role check and both the 'admin' and 'leader' role checks. We care if users are admin otherwise we treat them as leaders. I used that logic in the code below to simplify the privileges for users editing in the database.

This should be much cleaner and easier to read.
