### PR TITLE
Add "default open" feature to accordion

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -1,7 +1,6 @@
 //Accordion for mobile chapter index
 $(function() {
   $('#state-list .accordion').on('click', 'h2', function() {
-  	console.log(this);
       $(this).parent().removeClass("hidden").siblings().addClass("hidden");
   });
 });
@@ -36,6 +35,14 @@ $(function(){
 			    $(this).parent().find(".chevron-opened").removeClass("chevron-opened").addClass("chevron-closed");   
 			}
 	    });
+
+	    //Allow default open on chosen rows by setting h3 class to 'display-open'
+
+	    if($this.hasClass('display-open')){
+
+	    	// Trigger click to open
+	    	$this.children("button").click()
+	    }
 
 	});
 });

--- a/app/views/home/faq.html.erb
+++ b/app/views/home/faq.html.erb
@@ -8,7 +8,7 @@
         </div>
         <div class="collapsible">
       
-        <h3><span class="chevron-closed">&nbsp;</span>I’m interested in taking a class I saw on the website, when will you offer it my area and where can I sign up?</h3>
+        <h3 class="display-open"><span class="chevron-closed">&nbsp;</span>I’m interested in taking a class I saw on the website, when will you offer it my area and where can I sign up?</h3>
 		<div>
 		<p>For information on classes and workshops, <a href="/chapters">please visit the Chapters page</a> to find the chapter in your area. Schedules and contact information are listed on the individual chapter page.</p>
 		</div>

--- a/app/views/home/jobs.html.erb
+++ b/app/views/home/jobs.html.erb
@@ -14,7 +14,7 @@
 	      </div>
         <div class="collapsible">
       
-        <h3><span class="chevron-closed">&nbsp;</span>Operations Lead</h3>
+        <h3 class="display-open"><span class="chevron-closed">&nbsp;</span>Operations Lead</h3>
 		<div>
 			<h5>Location</h5>
 			<p>Philadelphia, PA or remote</p>


### PR DESCRIPTION
- Allows us to set rows to be shown as open on load
- Helps to demonstrate that the rows are clickable with more information to show
- A one-item accordion list can be shown as open until others are added
