### PR TITLE
Coordinator Section for Chapter Pages

### DIFF
--- a/app/admin/bio.rb
+++ b/app/admin/bio.rb
@@ -49,7 +49,7 @@ ActiveAdmin.register Bio do
         f.input :chapter_id, :input_html => { :value => current_admin_user.chapter_id }, as: :hidden
       end
       #f.input :admin_user
-      f.input :title, as: :select, collection: ['LEADERS', 'INSTRUCTORS', 'VOLUNTEERS']
+      f.input :title, as: :select, collection: ['LEADERS', 'COORDINATORS', 'INSTRUCTORS', 'VOLUNTEERS']
       f.input :name, placeholder: "Jane Doe"
       f.input :sort_order, as: :select, collection: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20], include_blank: false
       f.input :email, placeholder: current_admin_user.email

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -32,6 +32,7 @@ end
 
     @bios = @chapter.bios
     @leaders = @bios.where(title: "LEADERS").order("sort_order ASC")
+    @coordinators = @bios.where(title: "COORDINATORS").order("sort_order ASC")
     @instructors = @bios.where(title: "INSTRUCTORS").order("sort_order ASC")
     @volunteers = @bios.where(title: "VOLUNTEERS").order("sort_order ASC")
 

--- a/app/views/chapters/_profiles_sections.html.erb
+++ b/app/views/chapters/_profiles_sections.html.erb
@@ -1,0 +1,30 @@
+<div class="headline">
+  <%= image_tag 'flourish.png' %>
+  <h2><%= title %></h2>
+</div>
+
+<div class="profiles">
+  <% bios.each do |bio| %>
+    <div class="single-profile">
+      <div class="profile-img">
+        <% if bio.image? %>
+          <%= image_tag bio.image %>
+        <% elsif bio.pic_link? %>
+          <%= image_tag bio.pic_link %>
+        <% else %>
+          <%= image_tag "photo-not-available.jpg" %>
+        <% end %>
+      </div>
+
+      <div class="profile-content">
+        <h3><%= bio.name %></h3>
+        <% if bio.info[0, 3] == "<p>" %>
+          <%= bio.info.html_safe %>
+        <% else %>
+          <%= auto_link(simple_format(bio.info.html_safe)) %>
+        <% end %>
+        <%= render partial: "social_media_bio", locals: {bio: bio} %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -45,102 +45,137 @@
           <%= image_tag 'flourish.png' %>
           <h2>Chapter Leaders</h2>
         </div>
+
+        <div class="profiles">
+
+          <% @leaders.each do |bio| %>
+            <div class="single-profile">
+              <div class="profile-img">
+                <% if bio.image? %>
+                  <%= image_tag bio.image %>
+                <% elsif bio.pic_link? %>
+                  <%= image_tag bio.pic_link %>
+                <% else %>
+                  <%= image_tag "photo-not-available.jpg" %>
+                <% end %>
+              </div>
+
+              <div class="profile-content">
+                <h3><%= bio.name %></h3>
+                <% if bio.info[0, 3] == "<p>" %>
+                  <%= bio.info.html_safe %>
+                <% else %>
+                  <%= auto_link(simple_format(bio.info.html_safe)) %>
+                <% end %>
+                <%= render partial: "social_media_bio", locals: {bio: bio} %>
+              </div>
+            </div>
+          <% end %>
+        </div>
       <% end %>
 
-      <div class="profiles">
-
-        <% @leaders.each do |bio| %>
-          <div class="single-profile">
-            <div class="profile-img">
-              <% if bio.image? %>
-                <%= image_tag bio.image %>
-              <% elsif bio.pic_link? %>
-                <%= image_tag bio.pic_link %>
-              <% else %>
-                <%= image_tag "photo-not-available.jpg" %>
-              <% end %>
-            </div>
-
-            <div class="profile-content">
-              <h3><%= bio.name %></h3>
-              <% if bio.info[0, 3] == "<p>" %>
-                <%= bio.info.html_safe %>
-              <% else %>
-                <%= auto_link(simple_format(bio.info.html_safe)) %>
-              <% end %>
-              <%= render partial: "social_media_bio", locals: {bio: bio} %>
-            </div>
+      <% if @coordinators.count != 0 %>
+        <div class="profiles">
+          <div class="headline">
+            <%= image_tag 'apple.png' %>
+            <h2>The Coordinators</h2>
           </div>
-        <% end %>
-      </div>
 
-      <div class="profiles">
-        <% if @instructors.count != 0 %>
+          <% @coordinators.each do |bio| %>
+            <div class="single-profile">
+              <div class="profile-img">
+                <% if bio.image? %>
+                  <%= image_tag bio.image %>
+                <% elsif bio.pic_link? %>
+                  <%= image_tag bio.pic_link %>
+                <% else %>
+                  <%= image_tag "photo-not-available.jpg" %>
+                <% end %>
+              </div>
+
+              <div class="profile-content">
+                <h3><%= bio.name %></h3>
+                <% if bio.info[0, 3] == "<p>" %>
+                  <%= bio.info.html_safe %>
+                <% else %>
+                  <%= simple_format(bio.info.html_safe) %>
+                <% end %>
+                <%= render partial: "social_media_bio", locals: {bio: bio} %>
+
+              </div>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+
+      <% if @instructors.count != 0 %>
+        <div class="profiles">
           <div class="headline">
             <%= image_tag 'apple.png' %>
             <h2>The Instructors</h2>
           </div>
-        <% end %>
 
-        <% @instructors.each do |bio| %>
-          <div class="single-profile">
-            <div class="profile-img">
-              <% if bio.image? %>
-                <%= image_tag bio.image %>
-              <% elsif bio.pic_link? %>
-                <%= image_tag bio.pic_link %>
-              <% else %>
-                <%= image_tag "photo-not-available.jpg" %>
-              <% end %>
+          <% @instructors.each do |bio| %>
+            <div class="single-profile">
+              <div class="profile-img">
+                <% if bio.image? %>
+                  <%= image_tag bio.image %>
+                <% elsif bio.pic_link? %>
+                  <%= image_tag bio.pic_link %>
+                <% else %>
+                  <%= image_tag "photo-not-available.jpg" %>
+                <% end %>
+              </div>
+
+              <div class="profile-content">
+                <h3><%= bio.name %></h3>
+                <% if bio.info[0, 3] == "<p>" %>
+                  <%= bio.info.html_safe %>
+                <% else %>
+                  <%= simple_format(bio.info.html_safe) %>
+                <% end %>
+                <%= render partial: "social_media_bio", locals: {bio: bio} %>
+
+              </div>
             </div>
+          <% end %>
+        </div>
+      <% end %>
 
-            <div class="profile-content">
-              <h3><%= bio.name %></h3>
-              <% if bio.info[0, 3] == "<p>" %>
-                <%= bio.info.html_safe %>
-              <% else %>
-                <%= simple_format(bio.info.html_safe) %>
-              <% end %>
-              <%= render partial: "social_media_bio", locals: {bio: bio} %>
-
-            </div>
-          </div>
-        <% end %>
-      </div>
-
-      <div class="profiles">
-        <% if @volunteers.count != 0 %>
+      <% if @volunteers.count != 0 %>
+        <div class="profiles">
           <div class="headline">
             <%= image_tag 'apple.png' %>
             <h2>The Volunteers</h2>
           </div>
-        <% end %>
 
-        <% @volunteers.each do |bio| %>
-          <div class="single-profile">
-            <div class="profile-img">
-              <% if bio.image? %>
-                <%= image_tag bio.image %>
-              <% elsif bio.pic_link? %>
-                <%= image_tag bio.pic_link %>
-              <% else %>
-                <%= image_tag "photo-not-available.jpg" %>
-              <% end %>
+          <% @volunteers.each do |bio| %>
+            <div class="single-profile">
+              <div class="profile-img">
+                <% if bio.image? %>
+                  <%= image_tag bio.image %>
+                <% elsif bio.pic_link? %>
+                  <%= image_tag bio.pic_link %>
+                <% else %>
+                  <%= image_tag "photo-not-available.jpg" %>
+                <% end %>
+              </div>
+
+              <div class="profile-content">
+                <h3><%= bio.name %></h3>
+                <% if bio.info[0, 3] == "<p>" %>
+                  <%= bio.info.html_safe %>
+                <% else %>
+                  <%= simple_format(bio.info.html_safe) %>
+                <% end %>
+                <%= render partial: "social_media_bio", locals: {bio: bio} %>
+
+              </div>
             </div>
+          <% end %>
+        </div>
+      <% end %>
 
-            <div class="profile-content">
-              <h3><%= bio.name %></h3>
-              <% if bio.info[0, 3] == "<p>" %>
-                <%= bio.info.html_safe %>
-              <% else %>
-                <%= simple_format(bio.info.html_safe) %>
-              <% end %>
-              <%= render partial: "social_media_bio", locals: {bio: bio} %>
-
-            </div>
-          </div>
-        <% end %>
-      </div>
 
       <script type="text/template" id="meetup">
         <%% _.each( classesArr,function(course){ %>

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -41,138 +41,19 @@
       </div>
 
       <% if @leaders.count != 0 %>
-        <div class="headline">
-          <%= image_tag 'flourish.png' %>
-          <h2>Chapter Leaders</h2>
-        </div>
-
-        <div class="profiles">
-          <% @leaders.each do |bio| %>
-            <div class="single-profile">
-              <div class="profile-img">
-                <% if bio.image? %>
-                  <%= image_tag bio.image %>
-                <% elsif bio.pic_link? %>
-                  <%= image_tag bio.pic_link %>
-                <% else %>
-                  <%= image_tag "photo-not-available.jpg" %>
-                <% end %>
-              </div>
-
-              <div class="profile-content">
-                <h3><%= bio.name %></h3>
-                <% if bio.info[0, 3] == "<p>" %>
-                  <%= bio.info.html_safe %>
-                <% else %>
-                  <%= auto_link(simple_format(bio.info.html_safe)) %>
-                <% end %>
-                <%= render partial: "social_media_bio", locals: {bio: bio} %>
-              </div>
-            </div>
-          <% end %>
-        </div>
+       <%= render partial: "profiles_sections", locals: {title: 'The Leaders', bios: @leaders} %>
       <% end %>
 
       <% if @coordinators.count != 0 %>
-        <div class="headline">
-          <%= image_tag 'apple.png' %>
-          <h2>The Coordinators</h2>
-        </div>
-
-        <div class="profiles">
-          <% @coordinators.each do |bio| %>
-            <div class="single-profile">
-              <div class="profile-img">
-                <% if bio.image? %>
-                  <%= image_tag bio.image %>
-                <% elsif bio.pic_link? %>
-                  <%= image_tag bio.pic_link %>
-                <% else %>
-                  <%= image_tag "photo-not-available.jpg" %>
-                <% end %>
-              </div>
-
-              <div class="profile-content">
-                <h3><%= bio.name %></h3>
-                <% if bio.info[0, 3] == "<p>" %>
-                  <%= bio.info.html_safe %>
-                <% else %>
-                  <%= simple_format(bio.info.html_safe) %>
-                <% end %>
-                <%= render partial: "social_media_bio", locals: {bio: bio} %>
-
-              </div>
-            </div>
-          <% end %>
-        </div>
+        <%= render partial: "profiles_sections", locals: {title: 'The Coordinators', bios: @coordinators} %>
       <% end %>
 
       <% if @instructors.count != 0 %>
-          <div class="headline">
-            <%= image_tag 'apple.png' %>
-            <h2>The Instructors</h2>
-          </div>
-
-          <div class="profiles">
-          <% @instructors.each do |bio| %>
-            <div class="single-profile">
-              <div class="profile-img">
-                <% if bio.image? %>
-                  <%= image_tag bio.image %>
-                <% elsif bio.pic_link? %>
-                  <%= image_tag bio.pic_link %>
-                <% else %>
-                  <%= image_tag "photo-not-available.jpg" %>
-                <% end %>
-              </div>
-
-              <div class="profile-content">
-                <h3><%= bio.name %></h3>
-                <% if bio.info[0, 3] == "<p>" %>
-                  <%= bio.info.html_safe %>
-                <% else %>
-                  <%= simple_format(bio.info.html_safe) %>
-                <% end %>
-                <%= render partial: "social_media_bio", locals: {bio: bio} %>
-
-              </div>
-            </div>
-          <% end %>
-        </div>
+        <%= render partial: "profiles_sections", locals: {title: 'The Instructors', bios: @instructors} %>
       <% end %>
 
       <% if @volunteers.count != 0 %>
-          <div class="headline">
-            <%= image_tag 'apple.png' %>
-            <h2>The Volunteers</h2>
-          </div>
-
-          <div class="profiles">
-          <% @volunteers.each do |bio| %>
-            <div class="single-profile">
-              <div class="profile-img">
-                <% if bio.image? %>
-                  <%= image_tag bio.image %>
-                <% elsif bio.pic_link? %>
-                  <%= image_tag bio.pic_link %>
-                <% else %>
-                  <%= image_tag "photo-not-available.jpg" %>
-                <% end %>
-              </div>
-
-              <div class="profile-content">
-                <h3><%= bio.name %></h3>
-                <% if bio.info[0, 3] == "<p>" %>
-                  <%= bio.info.html_safe %>
-                <% else %>
-                  <%= simple_format(bio.info.html_safe) %>
-                <% end %>
-                <%= render partial: "social_media_bio", locals: {bio: bio} %>
-
-              </div>
-            </div>
-          <% end %>
-        </div>
+        <%= render partial: "profiles_sections", locals: {title: 'The Volunteers', bios: @volunteers} %>
       <% end %>
 
 

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -47,7 +47,6 @@
         </div>
 
         <div class="profiles">
-
           <% @leaders.each do |bio| %>
             <div class="single-profile">
               <div class="profile-img">
@@ -75,12 +74,12 @@
       <% end %>
 
       <% if @coordinators.count != 0 %>
-        <div class="profiles">
-          <div class="headline">
-            <%= image_tag 'apple.png' %>
-            <h2>The Coordinators</h2>
-          </div>
+        <div class="headline">
+          <%= image_tag 'apple.png' %>
+          <h2>The Coordinators</h2>
+        </div>
 
+        <div class="profiles">
           <% @coordinators.each do |bio| %>
             <div class="single-profile">
               <div class="profile-img">
@@ -109,12 +108,12 @@
       <% end %>
 
       <% if @instructors.count != 0 %>
-        <div class="profiles">
           <div class="headline">
             <%= image_tag 'apple.png' %>
             <h2>The Instructors</h2>
           </div>
 
+          <div class="profiles">
           <% @instructors.each do |bio| %>
             <div class="single-profile">
               <div class="profile-img">
@@ -143,12 +142,12 @@
       <% end %>
 
       <% if @volunteers.count != 0 %>
-        <div class="profiles">
           <div class="headline">
             <%= image_tag 'apple.png' %>
             <h2>The Volunteers</h2>
           </div>
 
+          <div class="profiles">
           <% @volunteers.each do |bio| %>
             <div class="single-profile">
               <div class="profile-img">


### PR DESCRIPTION
- Added Coordinators section of profiles for chapters in need of more roles
- To use, web admins can edit bios and set title to "COORDINATORS" and the member will appear under a new section
  - Originally just LEADERS, INSTRUCTORS, and VOLUNTEERS
  - Adds an additional layer of hierarchy for chapters as needed
  - Coordinator section will not appear unless at least one member is set
- Rearranged logic for all title sections to skip unless at least one member exists in each category.
  - Reduces empty divs showing up where no members are listed
