### PR TITLE
Swap Coordinators for Organizers

### DIFF
--- a/app/admin/bio.rb
+++ b/app/admin/bio.rb
@@ -49,7 +49,7 @@ ActiveAdmin.register Bio do
         f.input :chapter_id, :input_html => { :value => current_admin_user.chapter_id }, as: :hidden
       end
       #f.input :admin_user
-      f.input :title, as: :select, collection: ['LEADERS', 'COORDINATORS', 'INSTRUCTORS', 'VOLUNTEERS']
+      f.input :title, as: :select, collection: ['LEADERS', 'ORGANIZERS', 'INSTRUCTORS', 'VOLUNTEERS']
       f.input :name, placeholder: "Jane Doe"
       f.input :sort_order, as: :select, collection: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20], include_blank: false
       f.input :email, placeholder: current_admin_user.email

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -32,7 +32,7 @@ end
 
     @bios = @chapter.bios
     @leaders = @bios.where(title: "LEADERS").order("sort_order ASC")
-    @coordinators = @bios.where(title: "COORDINATORS").order("sort_order ASC")
+    @organizers = @bios.where(title: "ORGANIZERS").order("sort_order ASC")
     @instructors = @bios.where(title: "INSTRUCTORS").order("sort_order ASC")
     @volunteers = @bios.where(title: "VOLUNTEERS").order("sort_order ASC")
 

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -44,8 +44,8 @@
        <%= render partial: "profiles_sections", locals: {title: 'The Leaders', bios: @leaders} %>
       <% end %>
 
-      <% if @coordinators.count != 0 %>
-        <%= render partial: "profiles_sections", locals: {title: 'The Coordinators', bios: @coordinators} %>
+      <% if @organizers.count != 0 %>
+        <%= render partial: "profiles_sections", locals: {title: 'The Organizers', bios: @organizers} %>
       <% end %>
 
       <% if @instructors.count != 0 %>


### PR DESCRIPTION
- Added new role to the bio section of the site admin that was originally "Coordinators"
- Talked with HQ and the consensus is to switch to "Organizers"
- Same functionality, new and improved word!
- No database or back-end changes; just a text swap...
