### PR TITLE
 Add newsletter email input title

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -9,7 +9,7 @@
 			<form action="//girldevelopit.us2.list-manage.com/subscribe/post?u=4d5ae11ec6fb973947670055f&amp;id=e63c9ab02b" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
 			    <div id="mc_embed_signup_scroll">
 				<!-- <label for="mce-EMAIL">Subscribe to our mailing list</label><br> -->
-				<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" size="40" placeholder="email address" required>
+				<input type="email" value="" name="EMAIL" title="Email address" class="email" id="mce-EMAIL" size="40" placeholder="email address" required>
 			    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
 			    <div style="position: absolute; left: -5000px;"><input type="text" name="b_4d5ae11ec6fb973947670055f_e63c9ab02b" tabindex="-1" value=""></div>
 			    <div class="clear"><input type="submit" value="Subscribe to Mailing List" name="subscribe" id="mc-embedded-subscribe" class="button"></div>


### PR DESCRIPTION
This PR should fix issue #401. Title attribute is added for newsletter email address to avoid adding unnecessary label.
I've tried to test accessibility with http://webanywhere.cs.washington.edu/beta/, it would be great if @roenok or anyone else can check if it really works with a screen reader.
