### PR TITLE
FAQ text to lowercase, fixes #455

### DIFF
--- a/app/assets/stylesheets/about.css.scss
+++ b/app/assets/stylesheets/about.css.scss
@@ -115,6 +115,9 @@ h3.nocaps {
     margin-top: 10px;
     color: $black;
   }
+  h3 [aria-expanded] {
+    text-transform:none;
+  }
 }
 .board, .contact, .faqs {
   float: left;

--- a/app/assets/stylesheets/about.css.scss
+++ b/app/assets/stylesheets/about.css.scss
@@ -115,10 +115,14 @@ h3.nocaps {
     margin-top: 10px;
     color: $black;
   }
+}
+
+.faq{
   h3 [aria-expanded] {
     text-transform:none;
   }
 }
+
 .board, .contact, .faqs {
   float: left;
   display: block;


### PR DESCRIPTION
Overriding the h3 text-transform by setting it to "none" for the new selector ".faq"
- 2nd commit is due to .code being used on other pages. 
- Moved to .faq selector in order to avoid changes elsewhere.
