### PR TITLE
Adding is_active field to chapter sponsors

### DIFF
--- a/app/admin/sponsor.rb
+++ b/app/admin/sponsor.rb
@@ -4,7 +4,7 @@ ActiveAdmin.register Sponsor do
   # See permitted parameters documentation:
   # https://github.com/gregbell/active_admin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
   #
-  permit_params :sponsor, :name, :sort_order, :url, :name, :chapter, :chapter_id, :image
+  permit_params :sponsor, :name, :sort_order, :url, :name, :chapter, :chapter_id, :image, :is_active
 
   show do |ad|
     attributes_table do
@@ -29,6 +29,7 @@ ActiveAdmin.register Sponsor do
 
   form(:html => { :multipart => true }) do |f|
   f.inputs "Edit Sponsor" do
+      f.input :is_active, as: :radio, :collection => { "Yes" => true, "No" => false}, label: "Active?", include_blank: false
       if current_admin_user.admin?
         #admin can pick the chapter for the new sponsor using dropdown list :chapter
         f.input :chapter, member_label: :chapter, :collection => Chapter.active.order("chapter ASC")

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -28,7 +28,7 @@ end
       redirect_to @chapter, status: :moved_permanently
     end
     @users = @chapter.admin_users
-    @sponsors = @chapter.sponsors.order("sort_order ASC")
+    @sponsors = @chapter.sponsors.active.order("sort_order ASC")
 
     @bios = @chapter.bios
     @leaders = @bios.where(title: "LEADERS").order("sort_order ASC")

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -2,4 +2,7 @@ class Sponsor < ActiveRecord::Base
   resourcify
   belongs_to :chapter
   mount_uploader :image, SponsorImageUploader
+
+  scope :active, -> { where(is_active: true) }
+  
 end

--- a/db/migrate/20160621025651_add_is_active_to_sponsors.rb
+++ b/db/migrate/20160621025651_add_is_active_to_sponsors.rb
@@ -1,0 +1,5 @@
+class AddIsActiveToSponsors < ActiveRecord::Migration
+  def change
+    add_column :sponsors, :is_active, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151221234035) do
+ActiveRecord::Schema.define(version: 20160621025651) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -147,6 +147,7 @@ ActiveRecord::Schema.define(version: 20151221234035) do
     t.datetime "updated_at"
     t.string   "image"
     t.integer  "sort_order", default: 1
+    t.boolean  "is_active",  default: true
   end
 
 end


### PR DESCRIPTION
- Added is_active:boolean migration
- This allows chapter leaders to toggle sponsors on and off the chapter page as needed without losing data/information
