### PR TITLE
Adding toggle notes to database settings for vagrant/non-vagrant use cases

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -29,6 +29,8 @@ development:
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user that initialized the database.
+  
+  # !!IMPORTANT!! DISABLE IF *NOT* USING VAGRANT
   username: vagrant
 
   # The password associated with the postgres role (username).
@@ -37,6 +39,8 @@ development:
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have
   # domain sockets, so uncomment these lines.
+  
+  # !!IMPORTANT!! DISABLE IF USING VAGRANT
   #host: localhost
 
   # The TCP port the server listens on. Defaults to 5432.


### PR DESCRIPTION
The new vagrant changes may conflict with existing dev environments (like mine) so I added a couple notes to indicate when to use username/host settings in the database file.
