### PR TITLE
Added Vagrant installation to ReadTheDocs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,12 +1,13 @@
 site_name: Girl Develop It
 
-theme: readthedocs
-
 docs_dir: sources
 
+theme: readthedocs
+
 pages:
-- ['installation.md', 'Installation (Website)']
-- ['installation_docs.md', 'Installation (Docs)']
-- ['contribution.md', 'Contribution Guidelines']
-- ['deploying.md', 'Deploying to Heroku']
-- ['faq.md', 'Frequently Asked Questions']
+  - Home: 'index.md'
+  - Installation (Website): installation.md
+  - Installation (Docs): installation_docs.md
+  - Deploying to Heroku: 'deploying.md'
+  - Contribution Guidelines: 'contribution.md'
+  - Frequently Asked Questions: 'faq.md'

--- a/docs/sources/faq.md
+++ b/docs/sources/faq.md
@@ -21,6 +21,6 @@ After that, you can run `rails server` to start the server on port `3000` or `ra
 
 ### Upgrading PostgreSQL from 9.2.*
 
-1. Uninstall PostgreSQL. 
+1. Uninstall PostgreSQL.
 2. ```sh rm rf /usr/local/var/postgres/ ``` (or wherever you have your postgres/ directory).
 3. Install PostgreSQL 9.3.

--- a/docs/sources/installation.md
+++ b/docs/sources/installation.md
@@ -2,17 +2,20 @@
 
 Here are some requirements and guides to contributing to the Girl Develop It website code base. Be sure to review this when trying to install a local development environment! Be sure to reach out to us at [website@girldevelopit.com](mailto:website@girldevelopit.com) with questions.
 
+---
 
 ### Required installations
 * [homebrew](http://brew.sh/), a package manager for Mac OS X.
 * [rvm](http://rvm.io/), a command-line tool to manage different versions of Ruby.
 * ruby 2.1.7
 * PostgreSQL 9.3.+
-  * Install with homebrew using `brew install postgres` and follow the brew instructions for these with `brew update` and `brew doctor`. 
+  * Install with homebrew using `brew install postgres` and follow the brew instructions for these with `brew update` and `brew doctor`.
   * **OR**
   * Using [Postgres.app for Mac OS X](http://www.postgresql.org/download/macosx/) (recommended).
 
 **Note:** If you are upgrading from 9.2., please see instructions below for "Upgrading PostgreSQL from 9.2."
+
+---
 
 ### Setting up your local dev environment
 
@@ -59,6 +62,8 @@ $ echo $MEETUP_API_KEY
    `git remote add upstream git@github.com:girldevelopit/gdi-new-site.git`
 - Now test your local dev environment by running `rails s` and visiting http://0.0.0.0:3000. You should now see a local copy of the live website! \o/
 
+---
+
 ### Ubuntu installation instructions
 * Install RVM [Website Instructions](http://rvm.io/rvm/install)
   * Install the pgp key for rvm
@@ -72,7 +77,7 @@ $ echo $MEETUP_API_KEY
   * Source the RVM scripts (the output from the install command has instructions for how to set this up permanently)
   ```sh
   source ~/.rvm/scripts/rvm
-  ``` 
+  ```
 * Install Ruby
 ```sh
 rvm install 2.1.7
@@ -108,3 +113,52 @@ sudo apt-get install build-essential libpq-dev  imagemagick libmagickwand-dev no
 	  postgres=# CREATE ROLE <username> SUPERUSER LOGIN;
       postgres=# \q
 	 ```
+
+---
+
+### How to Vagrant
+
+<!-- To set up the Vagrant environment locally:
+
+1. Install VirtualBox
+2. Install Vagrant
+3. clone the git repository
+4. `$ vagrant up`
+5. `$ vagrant ssh`
+6. `$ cd /opt/gdi/development`
+7. `$ bundle install`
+8. `$ rake db:create db:migrate db:seed`
+9. `$ bin/rails s`
+10. Point your browser to `localhost:3000`
+11. DEVELOP IT! \o/ -->
+
+#### 1. Install VirtualBox
+VirtualBox is a cross-platform virtualization application (see: [the VirtualBox manual](https://www.virtualbox.org/manual/ch01.html)). That means it can install multiple virtual machines at the same time, which is great for development. You can download the latest version on [the VirtualBox website](https://www.virtualbox.org/wiki/Downloads).
+
+#### 2. Install Vagrant
+Vagrant is a wonderful tool to help you build complete development environments. Download the latest version on [the Vagrant website](https://www.vagrantup.com/downloads.html).
+
+#### 3. Clone the gdi-website Git repository
+Clone the Git repository into your local development folder: `git@github.com:girldevelopit/gdi-website.git`
+
+#### 4. Start Vagrant
+Depending on your machine, this could take a while.
+
+```
+$ vagrant up
+$ vagrant ssh
+```
+
+#### 6. Install and initialize the development environment
+
+Run the following:
+
+```
+$ cd /opt/gdi/development
+$ bundle install
+$ rake db:create db:migrate db:seed
+$ bin/rails s
+```
+
+#### 7. View website
+Test your connection in a browser: `localhost:3000`


### PR DESCRIPTION
re: #471

Updated **ReadTheDocs > Installation (Website)** with the new Vagrant install information (found in the main repo `readme.md`).

screenshot:

![gdi-website_update-docs_vagrant-install](https://cloud.githubusercontent.com/assets/6895471/16906635/e05837fa-4c6f-11e6-813c-f5b6875b4d3d.png)

I left the original instructions inside a comment since I wasn't sure how much customization and content editing was required 😸  Also updated the mkdocs config (`mkdocs.yml`) with the correct page config (see: [Adding Pages](https://mkdocs.readthedocs.io/en/stable/#adding-pages))
