### PR TITLE
Closes #478 add padding to about page profile grafs

### DIFF
--- a/app/assets/stylesheets/about.css.scss
+++ b/app/assets/stylesheets/about.css.scss
@@ -124,6 +124,10 @@ h3.nocaps {
     text-align: center;
     @extend %dashed-border;
   }
+
+  p {
+    padding: 10px 0px;
+  }
 }
 
 .code {


### PR DESCRIPTION
Here's how the About page looks now:

![screen shot 2016-07-20 at 9 31 56 pm](https://cloud.githubusercontent.com/assets/12717458/17009457/ce46f780-4ec8-11e6-8303-8b06bc820e72.png)

Rather than creating a general rule for all paragraphs to have a certain amount padding, I added padding for paragraphs in the About page's 'profile' class. The rest of the website looks good to me otherwise.
