### PR TITLE
Add chapter contact info to sponsors list, closes #466

### DIFF
--- a/app/assets/stylesheets/sponsors.css.scss
+++ b/app/assets/stylesheets/sponsors.css.scss
@@ -5,6 +5,7 @@
   }
   p{
     color: $black;
+    font-style: italic;
   }
 }
 

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -27,6 +27,10 @@
                 <% end %>
               <% end %>
             </div>
+            <p>
+              Interested in becoming a sponsor?
+              <%= mail_to @chapter.email, "Contact the chapter", subject: "Sponsoring the #{@chapter.chapter} Chapter" %>
+            </p>
           </div>
       <% end %>
     </aside>


### PR DESCRIPTION
Added a CTA to the sponsor list for future sponsorship opportunities. Links to chapter's email with subject line: "Sponsoring the [chapter name here] Chapter" 

Open to suggestions or adjustments!

Example:
<img width="261" alt="screen shot 2016-07-24 at 10 05 33 pm" src="https://cloud.githubusercontent.com/assets/6612770/17088630/adeda4d6-51eb-11e6-8015-0d394506ffeb.png">
