### PR TITLE
Get Involved Page with Chapter Leader Description

### DIFF
--- a/app/assets/stylesheets/home-page.css.scss
+++ b/app/assets/stylesheets/home-page.css.scss
@@ -189,8 +189,8 @@
   }
 }
 
-.jobs, .faq{
-
+.jobs, .faq, .get-involved{
+  
   min-height:500px;
 
   h5{
@@ -208,6 +208,12 @@
   .large{
       text-align: center;
       margin-bottom: 20px;
+  }
+  .sub-header{
+    font-weight:400;
+  }
+  .sub-paragraph{
+    margin-left:25px;
   }
 }
 

--- a/app/views/home/_chapter_leader.erb
+++ b/app/views/home/_chapter_leader.erb
@@ -1,0 +1,68 @@
+<% #Add the 'display-open' h3 class to display as opened on load %>
+<h3 class="display-open"><span class="chevron-closed">&nbsp;</span>Chapter Leader</h3>
+<div>
+	<h5>About Girl Develop It</h5>
+	<p>
+		Girl Develop It is a 501(c)3 nonprofit organization that provides affordable and judgment-free opportunities for adult women interested in learning web and software development. Through in-person classes and community support, Girl Develop It helps women of diverse backgrounds achieve their technology goals and build confidence in their careers and their everyday lives.
+	</p>
+	<h5>About this Role</h5>
+	<p>
+		As a <strong>Girl Develop It Chapter Leader</strong>, you'll empower women while growing your professional network and improving your business and leadership skills. Becoming a Chapter Leader is a unique opportunity that puts you in a position to further the professional development of not only hundreds and potentially thousands of women, but yourself as well. Some of the many benefits of joining Girl Develop It as a Chapter Leader include:
+	</p>
+	<p class="sub-paragraph">
+		<span class="sub-header">Network Access:</span><br/>
+		Join a strong community of dedicated leaders who come from diverse professional backgrounds. Gain access to information about opportunities to participate in conferences, organizations, and companies that focus on women and/or technology development. 
+	</p>
+	<p class="sub-paragraph">
+		<span class="sub-header">Leadership Development:</span><br/>
+		You'll have the opportunity to attend GDI's annual national leadership summit, where you can connect with other local leaders, and the national GDI leadership team. Additionally, you will have continuous access to resources that can further your growth as a leader and technologist. You’ll also receive direct support and professional development from the GDI Program Director and Headquarters team. 
+	</p>
+	<p class="sub-paragraph">
+		<span class="sub-header">Business Experience:</span><br/>
+		You and your leadership team will be responsible for the chapter's class and event operations, marketing, and budget. You'll lead your local team as your chapter grows and evolves. The skills you'll gain from working with GDI are invaluable and transferable to any job, company, or organization.
+	</p>
+	<h5>What makes a successful Chapter Leader?</h5>
+	<p>
+		A passionate and driven Chapter Leader (CL) is the key to a thriving Girl Develop It chapter. Chapter Leaders should be thoughtful teammates, driven managers, and courageous leaders. Chapter Leaders should be committed to the Girl Develop It mission and willing to go above and beyond to see that it is consistently pursued. Chapter Leaders are responsible for leading the day-to-day operations and growth of their local Girl Develop It chapter, in coordination with the organization’s HQ leadership. Each chapter runs accessible and affordable in-person courses, study groups, professional development workshops, networking events, and more. 
+	</p>
+	<p>
+		This role is directly supported by the Program Director, with supplemental support from the entire Girl Develop It HQ staff. Chapter Leaders are fortunate to be a part of a community of over 200 fellow leaders who are always willing to help and provide advice on the professional and personal, including managing a successful GDI chapter.
+	</p>
+	<h5>Responsibilities</h5>
+	<p>
+	<ul>
+		<li>Commitment to Girl Develop It's mission and core values</li>
+		<li>Schedule and organize monthly in-person classes and events</li>
+		<li>Recruit co-leaders and grow local leadership team to run the chapter sustainably in coordination with HQ leadership</li>
+		<li>Recruit qualified local instructors and teaching assistants</li>
+		<li>Communicate regularly with Girl Develop It headquarters</li>
+		<li>Cultivate local partnership development efforts on behalf of the chapter</li>
+	</ul>
+	</p>
+
+	<h5>Requirements</h5>
+	<p>
+	<ul>
+		<li>Friendly customer service and communication skills (both verbal and written)</li>
+		<li>Understanding of the challenges of cultivating and supporting diverse audiences</li>
+		<li>Personal qualities of integrity, flexibility, and accountability</li>
+		<li>Ability to effectively manage and prioritize tasks</li>
+	</ul>
+	</p>
+
+	<h5>Optional Experience We’d Love to Hear About</h5>
+	<p>
+	<ul>
+		<li>Experience in a technical field (particularly web and software development-related)</li>
+		<li>Proficiency in Google Apps (including Gmail, Drive, and Apps for Business)</li>
+		<li>Experience in event planning and/or community management, group facilitation</li>
+	</ul>
+	</p>
+	<h5>Hours and Compensation</h5>
+	<p>
+	<ul>
+		<li>Chapter Leaders should be able to commit approximately 20-30 hours per month</li>
+		<li>Chapter Leaders receive organizer payment for each class they organize</li>
+	</ul>
+	</p>
+</div>

--- a/app/views/home/_chapter_leader_cities.html.erb
+++ b/app/views/home/_chapter_leader_cities.html.erb
@@ -1,0 +1,21 @@
+<div class="underlined-headline">
+	<h2>Chapter Leaders Needed</h2>
+	<hr>
+</div>
+<p>We are currently looking for Chapter Leaders in the following cities:
+	<ul>
+		<li>Grand Rapids, Michigan</li>
+		<li>Houston, Texas</li>
+		<li>Las Vegas, Nevada</li>
+		<li>Nashville, Tennessee</li>
+		<li>New Orleans, Louisiana</li>
+		<li>Oakland, California</li>
+		<li>Orange County, California</li>
+		<li>Portland, Oregon</li>
+		<li>San Antonio, Texas</li>
+		<li>Washington DC</li>
+	</ul>
+</p>
+<p>
+	If interested, please email a resume and brief cover letter to <a href="mailto:inquiries@girldevelopit.com" target="_blank">inquiries@girldevelopit.com</a> with subject GDI Chapter Leader Role-[City].
+</p>

--- a/app/views/home/_chapter_leader_cities.html.erb
+++ b/app/views/home/_chapter_leader_cities.html.erb
@@ -1,5 +1,5 @@
 <div class="underlined-headline">
-	<h2>Chapter Leaders Needed</h2>
+	<h2>Lead In Your Community</h2>
 	<hr>
 </div>
 <p>We are currently looking for Chapter Leaders in the following cities:

--- a/app/views/home/get-involved.erb
+++ b/app/views/home/get-involved.erb
@@ -3,14 +3,10 @@
 	<div class="container">
 	    <section class="code get-involved">
 	        <div class="underlined-headline">
-	          <h2>Join Our Community!</h2>
+	          <h2>Join Our Movement</h2>
 	          <hr>
 	        </div>
 			<p class="large">Girl Develop It is excited to offer different opportunities to get involved and join our community. Take a look below to see what may be available in your area!</p>
-			<div class="underlined-headline">
-				<h2>Available Roles</h2>
-				<hr>
-			</div>
 			<div class="collapsible">
 				<%= render partial: "chapter_leader" %>	
 			</div>

--- a/app/views/home/get-involved.erb
+++ b/app/views/home/get-involved.erb
@@ -1,0 +1,23 @@
+<% provide(:title, "Get Involved") %>
+<section class="main-container">
+	<div class="container">
+	    <section class="code get-involved">
+	        <div class="underlined-headline">
+	          <h2>Join Our Community!</h2>
+	          <hr>
+	        </div>
+			<p class="large">Girl Develop It is excited to offer different opportunities to get involved and join our community. Take a look below to see what may be available in your area!</p>
+			<div class="underlined-headline">
+				<h2>Available Roles</h2>
+				<hr>
+			</div>
+			<div class="collapsible">
+				<%= render partial: "chapter_leader" %>	
+			</div>
+			<div>
+				<%= render partial: "chapter_leader_cities" %>
+			</div>
+
+		</section>
+	</div>
+</section>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -20,6 +20,7 @@
 			<!--End mc_embed_signup-->
 			<nav class="navigation">
 				<%= link_to "about", about_path %>
+				<%= link_to "get involved", get_involved_path %>
 				<%= link_to "jobs", jobs_path %>
 				<%= link_to "faq", faq_path %>
 				<%= link_to "code of conduct", code_of_conduct_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   get 'code-of-conduct', to: 'home#code-of-conduct'
   get 'codeofconduct', to: redirect('code-of-conduct')
   get 'faq', to: 'home#faq'
+  get 'get-involved', to: 'home#get-involved'
   get 'jobs', to: 'home#jobs'
   get 'materials', to: 'materials#index'
   get 'curriculum', to: redirect('materials')


### PR DESCRIPTION
Changes include:
- New 'Get Involved' page linked in footer
- Added 'Chapter Leader' and 'Chapter Leader Cities' partials for quick changes
- Transposed role description from Google page into code
- Mimics jobs page layout for additional roles in the future if needed

![2016-12-04-18-41-localhost-3000](https://cloud.githubusercontent.com/assets/6612770/20870233/8637f200-ba52-11e6-96b7-3880f248789f.png)
