### PR TITLE
Fixing build bug for Readline

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ group :development do
   gem 'guard'
   gem 'better_errors'
   gem 'binding_of_caller'
+  gem 'rb-readline'
   # gem 'capistrano-rails'
 end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@ Vagrant.configure(2) do |config|
   # https://docs.vagrantup.com.
 
   # ssh agent forwarding
-  config.ssh.forward_agent = true
+  # config.ssh.forward_agent = true
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.


### PR DESCRIPTION
- Noticed a dependency we no longer satisfied. 

> Sorry, you can't use byebug without Readline. To solve this, you need to
    rebuild Ruby with Readline support.

- Added rb-readline as a development gem and all is well!
- Removed ssh forwarding that was added to a previous commit without explanation...