### PR TITLE
Fixing config order to restore staging deployment

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -3,12 +3,12 @@ CarrierWave.configure do |config|
   config.directory_permissions = 0777
 
   if Rails.env.production?
-    config.storage = :fog
     config.fog_credentials = {
         :provider               => 'AWS',
         :aws_access_key_id      => ENV['AWS_ACCESS_KEY_ID'],
         :aws_secret_access_key  => ENV['AWS_SECRET_ACCESS_KEY']
     }
+    config.storage = :fog
     config.fog_directory = ENV['S3_BUCKET_NAME']
   else
     config.storage = :file


### PR DESCRIPTION
Found a bug in the latest commits, which resulted in failed staging deployment on Heroku. Came across some related issues and am seeing if some config line changes help. 

More details: https://github.com/carrierwaveuploader/carrierwave/issues/2023