### PR TITLE
Quick fix for materials page routing

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
 
   get 'curriculum', to: redirect('materials')
 
-  resources :materials, only: [:index]
+  resources :materials, only: [:index, :show]
   get '/materials/:slug' => 'materials#show', as: :course
 
   resources :meetups, param: :slug, only: [:show]


### PR DESCRIPTION
Routing was recently cleaned up and a line was missed for viewing materials' inner pages e.g. slides, resources, etc. Quick fix!