### PR TITLE
Remove Director of Marketing job from jobs page

### DIFF
--- a/app/views/home/jobs.html.erb
+++ b/app/views/home/jobs.html.erb
@@ -6,15 +6,7 @@
 				<h2>Join our team!</h2>
 				<hr>
 			</div>
-			<p class="large">We are looking for enthusiastic individuals to join our team. Check out our open positions below!</p>
-			
-			<!-- <p class="large">We will be continuing to grow our team and posting more positions here in the coming months! Please check back and reach out to <a href="mailto:jobs@girldevelopit.com" target="_blank">jobs@girldevelopit.com</a> with any questions.</p> -->
-			<h2>Available Positions</h2>
-			<hr>
-			<div class="collapsible">
-				<%= render partial: "director_of_marketing" %>
-			</div>
-			
+			<p class="large">Currently there are no open positions.</p>
 		</section>
 	</div>
 </section>


### PR DESCRIPTION
Addresses: https://github.com/girldevelopit/gdi-website/issues/597

I can change the copy for the empty-state of the jobs page, but this is what it would look like with my changes:
<img width="679" alt="screen shot 2018-02-18 at 5 29 04 pm" src="https://user-images.githubusercontent.com/35879359/36357900-c461d7fe-14d2-11e8-9f3d-668f26c02627.png">
