### PR TITLE
Adding Rack::Attack for DDoS defense

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'meetup_client'
 gem 'underscore-rails'
 gem 'rails_autolink'
 gem 'video_player'
+gem 'rack-attack'
 
 # for aws cloud storage
 gem 'fog-aws'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,6 +227,8 @@ GEM
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.8)
+    rack-attack (5.4.0)
+      rack (>= 1.0, < 3)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.9)
@@ -374,6 +376,7 @@ DEPENDENCIES
   pg (~> 0.20.0)
   pry-byebug
   quiet_assets
+  rack-attack
   rails (= 4.2.9)
   rails_12factor
   rails_autolink

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,8 @@ module GdiMainSite
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    # Initialize Rack Attack to reduce DDOS attacks.
+    config.middleware.use Rack::Attack
   end
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,11 @@
+# Block suspicious requests for '/etc/password' or wordpress specific paths.
+# After 3 blocked requests in 10 minutes, block all requests from that IP for 5 minutes.
+Rack::Attack.blocklist('fail2ban ddos') do |req|
+  # `filter` returns truthy value if request fails, or if it's from a previously banned IP
+  # so the request is blocked
+  Rack::Attack::Fail2Ban.filter("ddos-#{req.ip}", maxretry: 3, findtime: 10.minutes, bantime: 5.minutes) do
+    # The count for the IP is incremented if the return value is truthy
+    req.path.include?('wp-login')
+
+  end
+end


### PR DESCRIPTION
I've noticed some DDoS attempts on the GDI website in the form of wp-login spamming. We currently and successfully redirect all the requests, but the ongoing attempts can slow down the site. Rack Attack will ban IPs that spam the website for ~5 min if attempted more than 3 times. I'll be monitoring to see if this is enough time or if we should up the ban length. 👍 